### PR TITLE
Explicitly set buildpack when pushing example app

### DIFF
--- a/service/service_test.go
+++ b/service/service_test.go
@@ -32,7 +32,7 @@ var _ = Describe("RabbitMQ Service", func() {
 
 	BeforeEach(func() {
 		appName = randomName()
-		Eventually(cf.Cf("push", appName, "-m", "256M", "-p", appPath, "-s", "cflinuxfs2", "-no-start"), config.ScaledTimeout(timeout)).Should(Exit(0))
+		Eventually(cf.Cf("push", appName, "-m", "256M", "-p", appPath, "-s", "cflinuxfs2", "-no-start", "-b", "ruby_buildpack"), config.ScaledTimeout(timeout)).Should(Exit(0))
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
This makes the test run a little faster and avoids timing out on slowed machines

Thanks,
@ekcasey and @mdelillo
